### PR TITLE
Dynamic enemy spawn positions

### DIFF
--- a/Assets/Scenes/Game.unity
+++ b/Assets/Scenes/Game.unity
@@ -11075,9 +11075,9 @@ MonoBehaviour:
   enemiesPerWave: 2
   spawnInterval: 5
   maxAliveEnemies: 5
-  spawnLocation: {fileID: 895236961}
   enemyPrefab: {fileID: 6911346458639847058, guid: 8e2346ccbc4a26d45a7bf2254de03d0c,
     type: 3}
+  spawnTag: EnemySpawnPoint
   enemyController: {fileID: 657520132}
   bulletTargetBehaviour: {fileID: 657520131}
 --- !u!1 &942188745

--- a/Assets/Scenes/Game.unity
+++ b/Assets/Scenes/Game.unity
@@ -3432,6 +3432,36 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 426935387}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &447069453
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 447069454}
+  m_Layer: 0
+  m_Name: Position_2
+  m_TagString: EnemySpawnPoint
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &447069454
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 447069453}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -29.61, y: 0, z: -0.57}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 895236961}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &459920808
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -10841,7 +10871,7 @@ GameObject:
   m_Component:
   - component: {fileID: 895236961}
   m_Layer: 0
-  m_Name: EnemySpawnPoint
+  m_Name: EnemySpawnPoints
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -10855,9 +10885,12 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 895236960}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 1.34, y: 0.6, z: -0.12}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
+  m_Children:
+  - {fileID: 1188123228}
+  - {fileID: 447069454}
+  - {fileID: 2110447986}
   m_Father: {fileID: 0}
   m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -13033,6 +13066,36 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1522353653}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1188123227
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1188123228}
+  m_Layer: 0
+  m_Name: Position_1
+  m_TagString: EnemySpawnPoint
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1188123228
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1188123227}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 895236961}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1209512555
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -19558,6 +19621,36 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 2093423373}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &2110447985
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2110447986}
+  m_Layer: 0
+  m_Name: Position_3
+  m_TagString: EnemySpawnPoint
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2110447986
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2110447985}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -29.61, y: 0, z: -0.57}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 895236961}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &2119571318 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 6476529798019570804, guid: 0fe65fec31a96cc49a3146a03f035c48,

--- a/Assets/Scenes/Game.unity
+++ b/Assets/Scenes/Game.unity
@@ -11110,6 +11110,8 @@ MonoBehaviour:
   maxAliveEnemies: 5
   enemyPrefab: {fileID: 6911346458639847058, guid: 8e2346ccbc4a26d45a7bf2254de03d0c,
     type: 3}
+  target: {fileID: 1153021228}
+  spawnZoneExclusion: 10
   spawnTag: EnemySpawnPoint
   enemyController: {fileID: 657520132}
   bulletTargetBehaviour: {fileID: 657520131}
@@ -19645,7 +19647,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2110447985}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -29.61, y: 0, z: -0.57}
+  m_LocalPosition: {x: -0.34, y: 0, z: -29.93}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 895236961}

--- a/Assets/Scripts/EnemySpawner.cs
+++ b/Assets/Scripts/EnemySpawner.cs
@@ -8,15 +8,34 @@ public class EnemySpawner : MonoBehaviour
     public int enemiesPerWave = 3;
     public float spawnInterval = 5f;
     public int maxAliveEnemies = 3;
-    public Transform spawnLocation;
     public GameObject enemyPrefab; // must have a NavMeshAgent component
+    public string spawnTag = "SpawnPoint";
 
     [Header("Required Managers")]
     public EnemyController enemyController;
     public BulletTargetBehaviour bulletTargetBehaviour;
 
+    private Transform[] spawnLocations;
     private List<GameObject> spawnedEnemies = new List<GameObject>();
     private float nextTimeToSpawn = 0f;
+
+    private void Awake()
+    {
+        GameObject[] spawnPointObjects = GameObject.FindGameObjectsWithTag(spawnTag);
+        if (spawnPointObjects.Length > 0)
+        {
+            spawnLocations = new Transform[spawnPointObjects.Length];
+            for (int i = 0; i < spawnPointObjects.Length; i++)
+            {
+                spawnLocations[i] = spawnPointObjects[i].transform;
+            }
+        }
+        else
+        {
+            Debug.LogError($"No game objects found with the tag '{spawnTag}'. Enemies will not spawn.");
+            this.enabled = false;
+        }
+    }
 
     private void Update()
     {
@@ -47,8 +66,12 @@ public class EnemySpawner : MonoBehaviour
 
     private void SpawnNewEnemy()
     {
-        Vector3 randomOffset = new Vector3(Random.Range(-5f, 5f), 1f, Random.Range(-5f, 5f)); // not overlap positions
-        Vector3 spawnPosition = spawnLocation.position + randomOffset;
+        if (spawnLocations == null || spawnLocations.Length == 0) return;
+
+        Transform usedSpawnLocation = spawnLocations[Random.Range(0, spawnLocations.Length)];
+
+        Vector3 randomOffset = new Vector3(Random.Range(-2f, 2f), 1f, Random.Range(-2f, 2f)); // not overlap positions
+        Vector3 spawnPosition = usedSpawnLocation.position + randomOffset;
         Quaternion spawnRotation = Quaternion.identity;
 
         GameObject newEnemy = Instantiate(enemyPrefab, spawnPosition, spawnRotation);

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -6,6 +6,7 @@ TagManager:
   tags:
   - Enemy
   - Ground
+  - EnemySpawnPoint
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
This pullrequest reworks the current enemy spawning to allow there to be multiple spawn points for them to make the game less predictable so the player can't just position himself and spawncamp them.

### Summary of Changes: 
* **Level Design**: added multiple empties to determine where the enemies can spawn
* **Scripting**: determine which spawnpoints to not use to spawn enemies being to close to the player

### Next steps:
* Test current positions and improve system by tweaking spawn positions & exclusion distances